### PR TITLE
Einheit bei chargeState.charger_power und driveState.power ist falsch

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -615,7 +615,7 @@
                 "name": "Charger Power",
                 "type": "number",
                 "role": "value",
-                "unit": "W",
+                "unit": "kW",
                 "read": true,
                 "write": false
             },

--- a/io-package.json
+++ b/io-package.json
@@ -897,7 +897,7 @@
                 "name": "Power",
                 "type": "number",
                 "role": "value.power.consumption",
-                "unit": "Wh",
+                "unit": "kWh",
                 "read": true,
                 "write": false
             },

--- a/io-package.json
+++ b/io-package.json
@@ -897,7 +897,7 @@
                 "name": "Power",
                 "type": "number",
                 "role": "value.power.consumption",
-                "unit": "kWh",
+                "unit": "kW",
                 "read": true,
                 "write": false
             },


### PR DESCRIPTION
Hi!

Sollte es nicht kW statt W sein? Bei meinem Model 3 wird jedenfalls kW geliefert. 